### PR TITLE
Fix relative paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Editor temp/swapfiles
+*~
+.*.swp
+
+# Node junk
+node_modules/
+npm-debug.log

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,8 @@
+{
+    "esversion": 6,
+    "globals": {
+        "jest": true
+    },
+    "jasmine": true,
+    "node": true
+}

--- a/main.html
+++ b/main.html
@@ -3,12 +3,18 @@
   <head>
     <meta charset="UTF-8">
 
-    <link href="../node_modules/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
-    <!-- If we are running as a library, we need a different path resolution -->
+    <!-- We need to try loading the css from whatever hierarchy we are in -->
+    <!-- This can be local folder, sibling folder, or parent folder -->
+    <!-- TODO: Try to make this a little less cludgy -->
+    <link href="node_modules/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="../bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="../../bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
 
-    <link href="../node_modules/node-syntaxhighlighter/lib/styles/shCoreDefault.css" rel="stylesheet">
-    <!-- If we are running as a library, we need a different path resolution -->
+    <!-- We need to try loading the css from whatever hierarchy we are in -->
+    <!-- This can be local folder, sibling folder, or parent folder -->
+    <!-- TODO: Try to make this a little less cludgy -->
+    <link href="node_modules/node-syntaxhighlighter/lib/styles/shCoreDefault.css" rel="stylesheet">
+    <link href="../node-syntaxhighlighter/lib/styles/shCoreDefault.css" rel="stylesheet">
     <link href="../../node-syntaxhighlighter/lib/styles/shCoreDefault.css" rel="stylesheet">
 
     <link href="./css/styles.css" rel="stylesheet" >


### PR DESCRIPTION
Depending on how we are running, we need to find our styles in the
node_modules directory which may be in different path. Loading these
sequentially generally doesn't cause problems as errors are silently
ignored and found CSS styling is applied.