### PR TITLE
Allow calling bin/hatch-previewer from other directories

### DIFF
--- a/bin/hatch-previewer
+++ b/bin/hatch-previewer
@@ -16,11 +16,11 @@ const allArgs = process.argv;
 const passedArgs = allArgs.slice(2);
 
 // Try to load us as a module if we're imported, otherwise if /app/main exists,
-// assume we're running in a flatpak package. Lastly, run from the current
+// assume we're running in a flatpak package. Lastly, run from the parent
 // directory.
 let pathToHatchPreviewerModule = '/app/main';
 if (!fs.existsSync(pathToHatchPreviewerModule))
-    pathToHatchPreviewerModule = path.resolve('.');
+    pathToHatchPreviewerModule = path.resolve(__dirname, '..');
 try {
     pathToHatchPreviewerModule = path.dirname(require.resolve('hatch-previewer'));
 } catch (e) {


### PR DESCRIPTION
Now non-flatpak standalone requires bin/hatch-previewer to be run from
the root of the repository.

Change path to the module to be the module path, not the current
directory, in the case where we are not in a flatpak package and not
imported as a module.

Otherwise if `PATH/TO/bin/hatch-previewer <path>` is called from an
ingester dir, the `index.js` of the ingester is executed!